### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-nnxuifdr/overlays/prod/deployment-patch.yaml
+++ b/components/go-nnxuifdr/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/dance-bootstrap-app:latest
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-nnxuifdr:github-75f5dd5a495d056111a6c17ee5d03c3ce32d650a
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-nnxuifdr:github-75f5dd5a495d056111a6c17ee5d03c3ce32d650a